### PR TITLE
Add AI ecosystem resources section

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -380,6 +380,83 @@ img {
   font-weight: 700;
 }
 
+.resource-grid {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.resource-card {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: var(--shadow-sm);
+  padding: 32px;
+  display: grid;
+  gap: 20px;
+}
+
+.resource-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.resource-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.resource-links li {
+  margin: 0;
+}
+
+.resource-links a {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(37, 99, 235, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.resource-links a:hover {
+  transform: translateY(-2px);
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: var(--shadow-sm);
+}
+
+.resource-links a:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.resource-link-text {
+  display: grid;
+  gap: 4px;
+}
+
+.resource-link-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.resource-link-desc {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.resource-link-icon {
+  font-size: 1rem;
+  color: var(--color-primary);
+  margin-top: 2px;
+}
+
 .card-label {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -97,6 +97,138 @@
         </div>
     </section>
 
+    <section class="section" id="ecosystem">
+        <div class="container">
+            <div class="section-head">
+                <span class="eyebrow">AI Ecosystem</span>
+                <h2 class="section-title">精选模型与营销工具，快速搭建 AI 增长基础</h2>
+                <p class="section-subtitle">常用的对话模型与网站资源集中收录，便于团队随时调用、快速启动与迭代。</p>
+            </div>
+            <div class="resource-grid">
+                <article class="resource-card">
+                    <span class="card-label">热门模型</span>
+                    <h3>主流 AI 对话模型</h3>
+                    <ul class="resource-links">
+                        <li>
+                            <a href="https://chat.openai.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">ChatGPT</span>
+                                    <span class="resource-link-desc">OpenAI 官方旗舰对话模型，支持多轮交流与应用插件。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.deepseek.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">DeepSeek</span>
+                                    <span class="resource-link-desc">国产长文本推理模型，提供高性价比的企业级部署能力。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://gemini.google.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Google Gemini</span>
+                                    <span class="resource-link-desc">Google 多模态模型，涵盖文本、图像、代码等跨模态协作。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.perplexity.ai/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Perplexity</span>
+                                    <span class="resource-link-desc">结合实时搜索的智能问答模型，适合调研与资料整理。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://grok.x.ai/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Grok</span>
+                                    <span class="resource-link-desc">xAI 推出的实时信息模型，紧密结合 X 平台数据生态。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.chatbot.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">ChatBot</span>
+                                    <span class="resource-link-desc">用于客服与销售的可视化对话机器人平台，支持多渠道接入。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://claude.ai/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Claude</span>
+                                    <span class="resource-link-desc">Anthropic 最新模型系列，强调安全性与长上下文处理能力。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                    </ul>
+                </article>
+                <article class="resource-card">
+                    <span class="card-label">增长工具</span>
+                    <h3>常用营销与数据网站</h3>
+                    <ul class="resource-links">
+                        <li>
+                            <a href="https://www.google.com/adsense/start/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Google AdSense</span>
+                                    <span class="resource-link-desc">网站广告变现平台，支持多种广告格式与收益分析。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://analytics.google.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Google Analytics</span>
+                                    <span class="resource-link-desc">网站与应用分析工具，实时洞察流量来源与用户行为。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://trends.google.com/trends/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Google Trends</span>
+                                    <span class="resource-link-desc">热门搜索趋势数据，帮助识别市场热点与内容机会。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://search.google.com/search-console/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Google Search Console</span>
+                                    <span class="resource-link-desc">监测站点在 Google 搜索中的表现，优化索引与 SEO 健康。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.spaceship.com/" target="_blank" rel="noopener">
+                                <div class="resource-link-text">
+                                    <span class="resource-link-title">Spaceship</span>
+                                    <span class="resource-link-desc">域名与托管服务平台，提供快速上线与协同的基础设施。</span>
+                                </div>
+                                <span class="resource-link-icon" aria-hidden="true">↗</span>
+                            </a>
+                        </li>
+                    </ul>
+                </article>
+            </div>
+        </div>
+    </section>
+
     <section class="section" id="services">
         <div class="container">
             <div class="section-head">


### PR DESCRIPTION
## Summary
- add an AI ecosystem section on the homepage with curated links to popular conversation models
- surface key marketing and analytics websites to complement AI resources
- introduce styling for the new resource cards and link list so they match the site's visual system

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d243c2346483219f199e86f74d6bb0