### PR TITLE
Add dedicated backlink resource page

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -380,6 +380,146 @@ img {
   font-weight: 700;
 }
 
+.links-hero {
+  padding: 140px 0 100px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(14, 116, 144, 0.1));
+  text-align: center;
+}
+
+.links-hero .container {
+  max-width: 780px;
+}
+
+.links-hero h1 {
+  margin: 20px 0 18px;
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  line-height: 1.2;
+}
+
+.links-hero .lead {
+  margin: 0 auto 32px;
+  color: var(--color-muted);
+}
+
+.links-anchors {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+}
+
+.section-head--center {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.links-group {
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  padding: 32px;
+  margin-bottom: 40px;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.links-group:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+
+.links-group__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.links-group__header i {
+  font-size: 1.6rem;
+  color: var(--color-primary);
+  margin-top: 4px;
+}
+
+.links-group__header h3 {
+  margin: 0 0 8px;
+  font-size: 1.5rem;
+}
+
+.links-group__header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.platform-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.platform-grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.platform-grid--four {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.platform-card {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  padding: 20px;
+  background: rgba(248, 250, 252, 0.6);
+  display: grid;
+  gap: 10px;
+  height: 100%;
+}
+
+.platform-card h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.platform-link {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.platform-link:hover {
+  color: var(--color-primary-dark);
+}
+
+.platform-meta {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.platform-note {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 768px) {
+  .links-hero {
+    padding: 120px 0 80px;
+  }
+
+  .links-group {
+    padding: 28px 24px;
+  }
+
+  .links-group__header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .links-group__header i {
+    margin-top: 0;
+  }
+}
+
 .resource-grid {
   display: grid;
   gap: 28px;

--- a/external-links.html
+++ b/external-links.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>外链资源合集 - AI Agent Box</title>
+    <meta name="description" content="收录国内外主流外链平台，包括行业媒体、问答社区、技术社区与商业目录，帮助品牌快速拓展权威背书与曝光渠道。">
+    <meta name="robots" content="index,follow">
+    <link rel="canonical" href="https://aiagentbox.com/external-links.html">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='86'>🤖</text></svg>">
+    <link rel="stylesheet" href="assets/styles.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer">
+</head>
+<body>
+<header class="site-header" id="top">
+    <div class="container header-inner">
+        <a class="logo" href="index.html" aria-label="返回 AI Agent Box 首页">AI Agent Box</a>
+        <nav class="site-nav" aria-label="主要导航">
+            <a href="index.html#services">核心服务</a>
+            <a href="index.html#solutions">解决方案</a>
+            <a href="index.html#advantages">我们的优势</a>
+            <a href="index.html#cases">成功案例</a>
+            <a href="index.html#insights">洞察</a>
+            <a href="index.html#faq">常见问题</a>
+            <a href="index.html#contact">联系我们</a>
+            <a href="external-links.html" aria-current="page">外链资源</a>
+        </nav>
+        <a class="btn btn--ghost" href="index.html#contact">预约咨询</a>
+    </div>
+</header>
+
+<main>
+    <section class="links-hero">
+        <div class="container">
+            <span class="eyebrow">Backlink Resources</span>
+            <h1>精选国内外外链平台，快速提升曝光与权威度</h1>
+            <p class="lead">我们按照媒体、社区、技术与商业目录等类型，整理适合品牌投放与合作的高质量站点。通过主动投稿、参与讨论与内容分发，帮助业务建立多渠道的外链资产。</p>
+            <div class="links-anchors" aria-label="页面快速导航">
+                <a class="btn btn--secondary" href="#china">国内平台</a>
+                <a class="btn btn--secondary" href="#global">国外平台</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="section link-section" id="china">
+        <div class="container">
+            <div class="section-head section-head--center">
+                <h2 class="section-title">🇨🇳 国内外链平台</h2>
+                <p class="section-subtitle">从行业媒体到技术社区，合理布局国内外链阵地，可以提升品牌曝光、站点权威与潜在客户触达效率。</p>
+            </div>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-newspaper" aria-hidden="true"></i>
+                    <div>
+                        <h3>行业媒体与博客</h3>
+                        <p>高权重媒体平台，适合通过投稿、访客文章或深度合作获取优质外链。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://36kr.com/" target="_blank" rel="noopener">36氪</a></h4>
+                        <p class="platform-meta">科技、商业、创投</p>
+                        <p class="platform-note">权威科技媒体，适合科技类内容投稿。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.huxiu.com/" target="_blank" rel="noopener">虎嗅网</a></h4>
+                        <p class="platform-meta">商业、科技、文化</p>
+                        <p class="platform-note">知名商业媒体，内容质量高。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.chinaz.com/" target="_blank" rel="noopener">站长之家</a></h4>
+                        <p class="platform-meta">站长工具、SEO、网站建设</p>
+                        <p class="platform-note">SEO 和网站建设专业平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://lusongsong.com/" target="_blank" rel="noopener">卢松松博客</a></h4>
+                        <p class="platform-meta">个人博客、网络推广、SEO</p>
+                        <p class="platform-note">知名 SEO 博主，权重较高。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-question-circle" aria-hidden="true"></i>
+                    <div>
+                        <h3>问答社区与知识分享平台</h3>
+                        <p>通过专业回答与知识分享，自然植入链接，兼顾曝光与口碑。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.zhihu.com/" target="_blank" rel="noopener">知乎</a></h4>
+                        <p class="platform-note">高质量问答社区，权重极高。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://zhidao.baidu.com/" target="_blank" rel="noopener">百度知道</a></h4>
+                        <p class="platform-note">百度旗下问答平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.douban.com/" target="_blank" rel="noopener">豆瓣</a></h4>
+                        <p class="platform-note">文化、生活类内容平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-share-alt" aria-hidden="true"></i>
+                    <div>
+                        <h3>社交媒体与内容平台</h3>
+                        <p>Nofollow 链接亦能带来直接流量与品牌曝光，对 SEO 同样重要。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://mp.weixin.qq.com/" target="_blank" rel="noopener">微信公众号</a></h4>
+                        <p class="platform-note">内容发布和传播平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://weibo.com/" target="_blank" rel="noopener">微博</a></h4>
+                        <p class="platform-note">社交媒体平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.xiaohongshu.com/" target="_blank" rel="noopener">小红书</a></h4>
+                        <p class="platform-note">生活方式分享平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.bilibili.com/" target="_blank" rel="noopener">Bilibili (B站)</a></h4>
+                        <p class="platform-note">视频内容平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-code" aria-hidden="true"></i>
+                    <div>
+                        <h3>技术开发社区</h3>
+                        <p>通过技术分享、开源项目与问答互动建立专业权威与外链。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.csdn.net/" target="_blank" rel="noopener">CSDN</a></h4>
+                        <p class="platform-meta">程序员社区，技术文章</p>
+                        <p class="platform-note">国内最大程序员社区。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://juejin.cn/" target="_blank" rel="noopener">掘金</a></h4>
+                        <p class="platform-meta">前端、后端技术分享</p>
+                        <p class="platform-note">高质量技术内容平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://segmentfault.com/" target="_blank" rel="noopener">SegmentFault</a></h4>
+                        <p class="platform-meta">技术问答社区</p>
+                        <p class="platform-note">专业的技术问答平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.oschina.net/" target="_blank" rel="noopener">开源中国</a></h4>
+                        <p class="platform-meta">开源技术、软件开发</p>
+                        <p class="platform-note">开源技术交流平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.cnblogs.com/" target="_blank" rel="noopener">博客园</a></h4>
+                        <p class="platform-meta">技术博客平台</p>
+                        <p class="platform-note">程序员博客社区。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-briefcase" aria-hidden="true"></i>
+                    <div>
+                        <h3>商业与行业平台</h3>
+                        <p>算法驱动内容平台，适合品牌内容分发与宣传推广。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.toutiao.com/" target="_blank" rel="noopener">今日头条</a></h4>
+                        <p class="platform-meta">自媒体内容平台</p>
+                        <p class="platform-note">算法推荐内容平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://mp.sohu.com/" target="_blank" rel="noopener">搜狐号</a></h4>
+                        <p class="platform-meta">内容创作平台</p>
+                        <p class="platform-note">搜狐旗下内容平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://dy.163.com/" target="_blank" rel="noopener">网易号</a></h4>
+                        <p class="platform-meta">媒体发布平台</p>
+                        <p class="platform-note">网易旗下内容平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.yidianzixun.com/" target="_blank" rel="noopener">一点资讯</a></h4>
+                        <p class="platform-meta">个性化资讯平台</p>
+                        <p class="platform-note">个性化推荐平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://om.qq.com/" target="_blank" rel="noopener">企鹅号</a></h4>
+                        <p class="platform-meta">腾讯内容开放平台</p>
+                        <p class="platform-note">腾讯旗下内容平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-comments" aria-hidden="true"></i>
+                    <div>
+                        <h3>论坛社区</h3>
+                        <p>老牌社区用户粘性高，适合互动交流与软性推广。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="http://www.tianya.cn/" target="_blank" rel="noopener">天涯社区</a></h4>
+                        <p class="platform-meta">综合性论坛</p>
+                        <p class="platform-note">老牌综合性论坛。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://tieba.baidu.com/" target="_blank" rel="noopener">贴吧</a></h4>
+                        <p class="platform-meta">百度贴吧</p>
+                        <p class="platform-note">百度旗下论坛平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="http://www.mop.com/" target="_blank" rel="noopener">猫扑</a></h4>
+                        <p class="platform-meta">娱乐社区</p>
+                        <p class="platform-note">娱乐类论坛社区。</p>
+                    </div>
+                </div>
+            </article>
+        </div>
+    </section>
+
+    <section class="section link-section" id="global">
+        <div class="container">
+            <div class="section-head section-head--center">
+                <h2 class="section-title">🌍 国外外链平台</h2>
+                <p class="section-subtitle">覆盖全球主流媒体、内容平台与行业站点，帮助团队在国际市场建立声誉与搜索表现。</p>
+            </div>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-newspaper" aria-hidden="true"></i>
+                    <div>
+                        <h3>新闻与商业媒体</h3>
+                        <p>全球知名高权威媒体，争取报道可显著提升品牌背书。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.forbes.com/" target="_blank" rel="noopener">Forbes</a></h4>
+                        <p class="platform-meta">商业、金融、科技</p>
+                        <p class="platform-note">全球知名商业媒体。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://techcrunch.com/" target="_blank" rel="noopener">TechCrunch</a></h4>
+                        <p class="platform-meta">新兴科技、创业公司</p>
+                        <p class="platform-note">权威科技媒体。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.wired.com/" target="_blank" rel="noopener">Wired</a></h4>
+                        <p class="platform-meta">科技、文化、设计</p>
+                        <p class="platform-note">科技文化杂志。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.nytimes.com/" target="_blank" rel="noopener">The New York Times</a></h4>
+                        <p class="platform-meta">综合新闻</p>
+                        <p class="platform-note">权威新闻媒体。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-edit" aria-hidden="true"></i>
+                    <div>
+                        <h3>内容发布与问答社区</h3>
+                        <p>直接发布文章或参与讨论，在专业圈层建立影响力。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.quora.com/" target="_blank" rel="noopener">Quora</a></h4>
+                        <p class="platform-meta">全球性问答社区</p>
+                        <p class="platform-note">高质量问答平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.reddit.com/" target="_blank" rel="noopener">Reddit</a></h4>
+                        <p class="platform-meta">各种主题社区</p>
+                        <p class="platform-note">针对垂直板块进行互动。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://medium.com/" target="_blank" rel="noopener">Medium</a></h4>
+                        <p class="platform-meta">内容发布平台</p>
+                        <p class="platform-note">高质量内容发布平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-share-alt" aria-hidden="true"></i>
+                    <div>
+                        <h3>社交媒体与本地目录</h3>
+                        <p>结合社交媒体与本地化入口，建立品牌可信度与曝光。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.linkedin.com/" target="_blank" rel="noopener">LinkedIn</a></h4>
+                        <p class="platform-meta">职业社交</p>
+                        <p class="platform-note">适合 B2B 业务。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.youtube.com/" target="_blank" rel="noopener">YouTube</a></h4>
+                        <p class="platform-meta">视频平台</p>
+                        <p class="platform-note">在视频描述中添加链接。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.google.com/business/" target="_blank" rel="noopener">Google My Business</a></h4>
+                        <p class="platform-meta">本地商家</p>
+                        <p class="platform-note">本地商家最重要的平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.yelp.com/" target="_blank" rel="noopener">Yelp</a></h4>
+                        <p class="platform-meta">本地商家点评</p>
+                        <p class="platform-note">本地商家点评与推荐。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-bullhorn" aria-hidden="true"></i>
+                    <div>
+                        <h3>内容营销平台</h3>
+                        <p>关注营销与增长领域的专业站点，获取行业话语权。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://blog.hubspot.com/" target="_blank" rel="noopener">HubSpot Blog</a></h4>
+                        <p class="platform-meta">营销、销售内容</p>
+                        <p class="platform-note">权威营销博客。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://contentmarketinginstitute.com/" target="_blank" rel="noopener">Content Marketing Institute</a></h4>
+                        <p class="platform-note">内容营销权威机构。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.marketingprofs.com/" target="_blank" rel="noopener">MarketingProfs</a></h4>
+                        <p class="platform-note">营销专业平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.socialmediaexaminer.com/" target="_blank" rel="noopener">Social Media Examiner</a></h4>
+                        <p class="platform-note">社交媒体营销平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-code" aria-hidden="true"></i>
+                    <div>
+                        <h3>技术与开发社区</h3>
+                        <p>展示项目与技术成果，吸引潜在合作与技术关注。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--three">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://stackoverflow.com/" target="_blank" rel="noopener">Stack Overflow</a></h4>
+                        <p class="platform-meta">程序员问答社区</p>
+                        <p class="platform-note">全球最大程序员社区。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://github.com/" target="_blank" rel="noopener">GitHub</a></h4>
+                        <p class="platform-meta">代码托管</p>
+                        <p class="platform-note">项目展示与代码托管。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://dev.to/" target="_blank" rel="noopener">Dev.to</a></h4>
+                        <p class="platform-meta">开发者社区</p>
+                        <p class="platform-note">开发者内容平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://news.ycombinator.com/" target="_blank" rel="noopener">Hacker News</a></h4>
+                        <p class="platform-meta">科技新闻讨论</p>
+                        <p class="platform-note">硅谷科技新闻社区。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.producthunt.com/" target="_blank" rel="noopener">Product Hunt</a></h4>
+                        <p class="platform-meta">新产品发布平台</p>
+                        <p class="platform-note">产品发布与发现平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-star" aria-hidden="true"></i>
+                    <div>
+                        <h3>商业目录与评论网站</h3>
+                        <p>通过第三方评价平台积累口碑，提高潜在客户信任度。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.bbb.org/" target="_blank" rel="noopener">Better Business Bureau</a></h4>
+                        <p class="platform-meta">商业信誉评级</p>
+                        <p class="platform-note">商业信誉认证平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.trustpilot.com/" target="_blank" rel="noopener">Trustpilot</a></h4>
+                        <p class="platform-meta">客户评价平台</p>
+                        <p class="platform-note">客户评价与信任平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.capterra.com/" target="_blank" rel="noopener">Capterra</a></h4>
+                        <p class="platform-meta">软件评测平台</p>
+                        <p class="platform-note">软件评测与比较。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.g2.com/" target="_blank" rel="noopener">G2</a></h4>
+                        <p class="platform-meta">软件评测和比较</p>
+                        <p class="platform-note">B2B 软件评测平台。</p>
+                    </div>
+                </div>
+            </article>
+
+            <article class="links-group">
+                <header class="links-group__header">
+                    <i class="fas fa-palette" aria-hidden="true"></i>
+                    <div>
+                        <h3>行业特定平台</h3>
+                        <p>在垂直行业平台展示案例与作品，吸引精准受众。</p>
+                    </div>
+                </header>
+                <div class="platform-grid platform-grid--four">
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.behance.net/" target="_blank" rel="noopener">Behance</a></h4>
+                        <p class="platform-meta">创意作品展示</p>
+                        <p class="platform-note">Adobe 旗下创意平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://dribbble.com/" target="_blank" rel="noopener">Dribbble</a></h4>
+                        <p class="platform-meta">设计师社区</p>
+                        <p class="platform-note">设计师作品展示平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://angel.co/" target="_blank" rel="noopener">AngelList</a></h4>
+                        <p class="platform-meta">创业公司和投资</p>
+                        <p class="platform-note">创业投资平台。</p>
+                    </div>
+                    <div class="platform-card">
+                        <h4><a class="platform-link" href="https://www.crunchbase.com/" target="_blank" rel="noopener">Crunchbase</a></h4>
+                        <p class="platform-meta">公司和投资信息</p>
+                        <p class="platform-note">创业公司数据库。</p>
+                    </div>
+                </div>
+            </article>
+        </div>
+    </section>
+</main>
+
+<footer class="site-footer">
+    <div class="container footer-inner">
+        <div class="footer-brand">
+            <h2>AI Agent Box</h2>
+            <p>AI 驱动的增长与运营顾问，帮助品牌和团队打造可持续的商业引擎。</p>
+        </div>
+        <div class="footer-links">
+            <strong>导航</strong>
+            <a href="index.html#services">核心服务</a>
+            <a href="index.html#solutions">解决方案</a>
+            <a href="index.html#cases">成功案例</a>
+            <a href="index.html#insights">洞察</a>
+            <a href="external-links.html">外链资源</a>
+        </div>
+        <div class="footer-links">
+            <strong>联系我们</strong>
+            <a href="mailto:hi@aiagentbox.org">hi@aiagentbox.org</a>
+            <a href="https://wa.me/8613900000000" target="_blank" rel="noopener">WhatsApp 咨询</a>
+            <span>微信：aiagentbox</span>
+            <span>地址：深圳 · 上海 · 远程团队</span>
+        </div>
+        <div class="footer-links">
+            <strong>关注我们</strong>
+            <a href="https://www.linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+            <a href="https://weibo.com" target="_blank" rel="noopener">微博</a>
+            <a href="https://www.zhihu.com" target="_blank" rel="noopener">知乎</a>
+        </div>
+        <p class="footer-note">© 2025 AI Agent Box. 保留所有权利。备案/许可证信息可根据政策更新。</p>
+    </div>
+</footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
             <a href="#insights">洞察</a>
             <a href="#faq">常见问题</a>
             <a href="#contact">联系我们</a>
+            <a href="external-links.html">外链资源</a>
         </nav>
         <a class="btn btn--ghost" href="#contact">预约咨询</a>
     </div>
@@ -545,6 +546,7 @@
             <a href="#solutions">解决方案</a>
             <a href="#cases">成功案例</a>
             <a href="#insights">洞察</a>
+            <a href="external-links.html">外链资源</a>
         </div>
         <div class="footer-links">
             <strong>联系我们</strong>

--- a/sitemap.html
+++ b/sitemap.html
@@ -22,6 +22,7 @@
             <a href="index.html#insights">洞察</a>
             <a href="index.html#faq">常见问题</a>
             <a href="index.html#contact">联系我们</a>
+            <a href="external-links.html">外链资源</a>
         </nav>
         <a class="btn btn--ghost" href="index.html#contact">预约咨询</a>
     </div>
@@ -65,6 +66,7 @@
                         <li><a href="index.html#insights">最新洞察</a> — 白皮书、实战案例与工作坊信息</li>
                         <li><a href="index.html#faq">常见问题</a> — 合作前的关键问题说明</li>
                         <li><a href="ai赚钱.html">AI赚钱资源库</a> — 汇总 AI 变现相关工具、域名与线索</li>
+                        <li><a href="external-links.html">外链资源合集</a> — 国内外权威平台收录，拓展品牌曝光</li>
                     </ul>
                 </article>
                 <article class="card">
@@ -94,6 +96,7 @@
             <a href="index.html#solutions">解决方案</a>
             <a href="index.html#cases">成功案例</a>
             <a href="index.html#insights">洞察</a>
+            <a href="external-links.html">外链资源</a>
         </div>
         <div class="footer-links">
             <strong>联系我们</strong>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,4 +21,10 @@
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>
     </url>
+    <url>
+        <loc>https://aiagentbox.com/external-links.html</loc>
+        <lastmod>2025-09-23</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+    </url>
 </urlset>


### PR DESCRIPTION
## Summary
- create an external-links page that curates domestic and international backlink platforms with grouped descriptions
- extend the shared stylesheet with layouts and card styles tailored for backlink resources
- link the new page from navigation, footer, and sitemap assets and register it in the XML sitemap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddb80cf3888321b093d5c589998ee6