### PR TITLE
Add Hotspot Game link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
             <a href="#faq">常见问题</a>
             <a href="#contact">联系我们</a>
             <a href="external-links.html">外链资源</a>
+            <a href="https://hotspotgame.online/" target="_blank" rel="noopener">热点游戏</a>
         </nav>
         <a class="btn btn--ghost" href="#contact">预约咨询</a>
     </div>


### PR DESCRIPTION
## Summary
- add a Hotspot Game menu item to the homepage navigation linking to hotspotgame.online

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c266d5b08321b65ab005564cba3e