### PR TITLE
Add AI 工具 link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
             <a href="#insights">洞察</a>
             <a href="#faq">常见问题</a>
             <a href="#contact">联系我们</a>
+            <a href="https://seodog.cn/" target="_blank" rel="noopener">AI 工具</a>
             <a href="external-links.html">外链资源</a>
             <a href="https://hotspotgame.online/" target="_blank" rel="noopener">热点游戏</a>
         </nav>


### PR DESCRIPTION
## Summary
- add an external AI 工具 link in the homepage navigation pointing to seodog.cn

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6902e42006448321b1135fa5dc950912